### PR TITLE
Remove extra types in tokens ast

### DIFF
--- a/src/plugins/tokens/tokens-ast.ts
+++ b/src/plugins/tokens/tokens-ast.ts
@@ -51,24 +51,9 @@ export type TokenValue =
   | ShadowTokenValue
   | TextStyleTokenValue
 
-export type ColorToken = {
-  qualifiedName: Array<string>
-  value: ColorTokenValue
-}
-
-export type ShadowToken = {
-  qualifiedName: Array<string>
-  value: ShadowTokenValue
-}
-
-export type TextStyleToken = {
-  qualifiedName: Array<string>
-  value: TextStyleTokenValue
-}
-
 export type Token = {
   qualifiedName: Array<string>
-  value: TextStyleTokenValue | ShadowTokenValue | ColorTokenValue
+  value: TokenValue
 }
 
 export type ConvertedFileContents = {


### PR DESCRIPTION
I'm removing these since they aren't used anywhere in the compiler, and I got confused for a sec about what they were for