### PR TITLE
work on plugin type

### DIFF
--- a/src/plugins/documentation/index.ts
+++ b/src/plugins/documentation/index.ts
@@ -84,9 +84,9 @@ async function convertWorkspace(
 
   await helpers.fs.writeFile('docs.json', JSON.stringify(workspace, null, '  '))
 }
-
 type ExpectedOptions = {}
-export default {
+const plugin: Plugin<ExpectedOptions, ConvertedWorkspace | void> = {
   format: 'documentation',
   convertWorkspace,
-} as Plugin<ExpectedOptions, ConvertedWorkspace | void>
+}
+export default plugin

--- a/src/plugins/documentation/index.ts
+++ b/src/plugins/documentation/index.ts
@@ -1,12 +1,11 @@
 import * as path from 'path'
 import { Helpers } from '../../helpers'
+import { Plugin } from '../index'
 import { ConvertedWorkspace, ConvertedFile } from './documentation-ast'
 import { convert } from './convert'
 import { findChildPages } from './utils'
 
 export { ConvertedWorkspace, ConvertedFile }
-
-export const format = 'documentation'
 
 export const convertFile = async (
   filePath: string,
@@ -41,14 +40,14 @@ export const convertFile = async (
 
 // depending on whether we have an output or not,
 // we return the doc or write it to disk
-export function convertWorkspace(
+function convertWorkspace(
   workspacePath: string,
   helpers: Helpers,
   options: {
     [key: string]: unknown
   } & { output?: never }
 ): Promise<ConvertedWorkspace>
-export function convertWorkspace(
+function convertWorkspace(
   workspacePath: string,
   helpers: Helpers,
   options: {
@@ -56,7 +55,7 @@ export function convertWorkspace(
   } & { output?: string }
 ): Promise<void>
 
-export async function convertWorkspace(
+async function convertWorkspace(
   workspacePath: string,
   helpers: Helpers,
   options: {
@@ -85,3 +84,9 @@ export async function convertWorkspace(
 
   await helpers.fs.writeFile('docs.json', JSON.stringify(workspace, null, '  '))
 }
+
+type ExpectedOptions = {}
+export default {
+  format: 'documentation',
+  convertWorkspace,
+} as Plugin<ExpectedOptions, ConvertedWorkspace | void>

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,6 +1,11 @@
 import { Helpers } from '../helpers'
 
-export type Plugin = {
+export interface Plugin<
+  ExpectedOptions extends { [argName: string]: any } = {
+    [argName: string]: unknown
+  },
+  T = unknown
+> {
   format: string
   convertWorkspace(
     workspacePath: string,
@@ -8,5 +13,5 @@ export type Plugin = {
     options: {
       [argName: string]: unknown
     }
-  ): Promise<any>
+  ): Promise<T>
 }

--- a/src/plugins/js/__tests__/js.test.ts
+++ b/src/plugins/js/__tests__/js.test.ts
@@ -29,7 +29,7 @@ describe('JS', () => {
         path.relative(workspace, filePath),
         helpers,
         {
-          ...((helpers.config.format || {})[formatter.format] || {}),
+          ...((helpers.config.format || {})[formatter.default.format] || {}),
         }
       )
 

--- a/src/plugins/js/index.ts
+++ b/src/plugins/js/index.ts
@@ -2,12 +2,11 @@ import * as path from 'path'
 import upperFirst from 'lodash.upperfirst'
 import camelCase from 'lodash.camelcase'
 import { Helpers } from '../../helpers'
+import { Plugin } from '../index'
 import convertLogic from './convert-logic'
 import renderJS from './render-ast'
 import * as JSAST from './js-ast'
 import { resolveImportPath } from './utils'
-
-export const format = 'js'
 
 export const convertFile = async (
   filePath: string,
@@ -40,7 +39,7 @@ export const convertFile = async (
   return `${renderJS(jsAST, { outputFile, reporter: helpers.reporter })}`
 }
 
-export const convertWorkspace = async (
+const convertWorkspace = async (
   workspacePath: string,
   helpers: Helpers,
   options: {
@@ -93,3 +92,11 @@ Object.keys(__lona_import_${i}).forEach(function (key) {
   //   './lona-helpers'
   // )
 }
+
+type ExpectedOptions = {
+  framework?: 'react' | 'react-native' | 'react-sketchapp'
+}
+export default {
+  format: 'js',
+  convertWorkspace,
+} as Plugin<ExpectedOptions, void>

--- a/src/plugins/js/index.ts
+++ b/src/plugins/js/index.ts
@@ -96,7 +96,8 @@ Object.keys(__lona_import_${i}).forEach(function (key) {
 type ExpectedOptions = {
   framework?: 'react' | 'react-native' | 'react-sketchapp'
 }
-export default {
+const plugin: Plugin<ExpectedOptions, void> = {
   format: 'js',
   convertWorkspace,
-} as Plugin<ExpectedOptions, void>
+}
+export default plugin

--- a/src/plugins/swift/__tests__/swift.test.ts
+++ b/src/plugins/swift/__tests__/swift.test.ts
@@ -29,7 +29,7 @@ describe('Swift', () => {
         path.relative(workspace, filePath),
         helpers,
         {
-          ...((helpers.config.format || {})[formatter.format] || {}),
+          ...((helpers.config.format || {})[formatter.default.format] || {}),
         }
       )
       expect(output).toMatchSnapshot()

--- a/src/plugins/swift/index.ts
+++ b/src/plugins/swift/index.ts
@@ -1,12 +1,11 @@
 import * as path from 'path'
 import upperFirst from 'lodash.upperfirst'
 import camelCase from 'lodash.camelcase'
+import { Plugin } from '../index'
 import { Helpers } from '../../helpers'
 import convertLogic from './convert-logic'
 import renderSwift from './render-ast'
 import * as SwiftAST from './swift-ast'
-
-export const format = 'swift'
 
 export const convertFile = async (
   filePath: string,
@@ -49,7 +48,7 @@ export const convertFile = async (
 ${renderSwift(swiftAST, { outputFile, reporter: helpers.reporter })}`
 }
 
-export const convertWorkspace = async (
+const convertWorkspace = async (
   workspacePath: string,
   helpers: Helpers,
   options: {
@@ -78,3 +77,9 @@ export const convertWorkspace = async (
     './lona-helpers'
   )
 }
+
+type ExpectedOptions = {}
+export default {
+  format: 'swift',
+  convertWorkspace,
+} as Plugin<ExpectedOptions, void>

--- a/src/plugins/swift/index.ts
+++ b/src/plugins/swift/index.ts
@@ -79,7 +79,8 @@ const convertWorkspace = async (
 }
 
 type ExpectedOptions = {}
-export default {
+const plugin: Plugin<ExpectedOptions, void> = {
   format: 'swift',
   convertWorkspace,
-} as Plugin<ExpectedOptions, void>
+}
+export default plugin

--- a/src/plugins/tokens/index.ts
+++ b/src/plugins/tokens/index.ts
@@ -6,7 +6,7 @@ import { convert } from './convert'
 
 export { ConvertedWorkspace, ConvertedFile }
 
-const convertFile = async (
+export const convertFile = async (
   filePath: string,
   helpers: Helpers
 ): Promise<ConvertedFile> => {
@@ -83,7 +83,8 @@ async function convertWorkspace(
 }
 
 type ExpectedOptions = {}
-export default {
+const plugin: Plugin<ExpectedOptions, ConvertedWorkspace | void> = {
   format: 'tokens',
   convertWorkspace,
-} as Plugin<ExpectedOptions, ConvertedWorkspace | void>
+}
+export default plugin

--- a/src/plugins/tokens/index.ts
+++ b/src/plugins/tokens/index.ts
@@ -1,13 +1,12 @@
 import * as path from 'path'
 import { Helpers } from '../../helpers'
+import { Plugin } from '../index'
 import { ConvertedWorkspace, ConvertedFile } from './tokens-ast'
 import { convert } from './convert'
 
 export { ConvertedWorkspace, ConvertedFile }
 
-export const format = 'tokens'
-
-export const convertFile = async (
+const convertFile = async (
   filePath: string,
   helpers: Helpers
 ): Promise<ConvertedFile> => {
@@ -35,14 +34,14 @@ export const convertFile = async (
 
 // depending on whether we have an output or not,
 // we return the tokens or write them to disk
-export function convertWorkspace(
+function convertWorkspace(
   workspacePath: string,
   helpers: Helpers,
   options: {
     [key: string]: unknown
   } & { output?: never }
 ): Promise<ConvertedWorkspace>
-export function convertWorkspace(
+function convertWorkspace(
   workspacePath: string,
   helpers: Helpers,
   options: {
@@ -50,7 +49,7 @@ export function convertWorkspace(
   } & { output?: string }
 ): Promise<void>
 
-export async function convertWorkspace(
+async function convertWorkspace(
   workspacePath: string,
   helpers: Helpers,
   options: {
@@ -82,3 +81,9 @@ export async function convertWorkspace(
     JSON.stringify(workspace, null, '  ')
   )
 }
+
+type ExpectedOptions = {}
+export default {
+  format: 'tokens',
+  convertWorkspace,
+} as Plugin<ExpectedOptions, ConvertedWorkspace | void>

--- a/src/utils/find-plugin.ts
+++ b/src/utils/find-plugin.ts
@@ -15,7 +15,9 @@ const requireInterop = (path: string): any => {
  * - node_modules/lona-compiler-FORMAT
  * - ../plugins/FORMAT
  */
-export const findPlugin = (format: string): Plugin => {
+export const findPlugin = <ExpectedOptions>(
+  format: string
+): Plugin<ExpectedOptions> => {
   try {
     return requireInterop(`@lona/compiler-${format}`)
   } catch (err) {

--- a/src/utils/find-plugin.ts
+++ b/src/utils/find-plugin.ts
@@ -11,6 +11,7 @@ const requireInterop = (path: string): any => {
 }
 
 /** Look for a plugin in
+ * - FORMAT is FORMAT starts with a `.` or a `/` (heuristic for a path)
  * - node_modules/@lona/compiler-FORMAT
  * - node_modules/lona-compiler-FORMAT
  * - ../plugins/FORMAT
@@ -19,16 +20,23 @@ export const findPlugin = <ExpectedOptions>(
   format: string
 ): Plugin<ExpectedOptions> => {
   try {
-    return requireInterop(`@lona/compiler-${format}`)
+    if (format.startsWith('.') || format.startsWith('/')) {
+      return requireInterop(format)
+    }
+    throw new Error('not a path')
   } catch (err) {
     try {
-      return requireInterop(`lona-compiler-${format}`)
+      return requireInterop(`@lona/compiler-${format}`)
     } catch (err) {
       try {
-        return requireInterop(`../plugins/${format}`)
+        return requireInterop(`lona-compiler-${format}`)
       } catch (err) {
-        console.error(err)
-        throw new Error(`Could not find plugin ${format}`)
+        try {
+          return requireInterop(`../plugins/${format}`)
+        } catch (err) {
+          console.error(err)
+          throw new Error(`Could not find plugin ${format}`)
+        }
       }
     }
   }


### PR DESCRIPTION
A plugin can now define what options it expects (no verification yet so still `unknown` as the arg) so that

```
import { convert } from '@lona/compiler'
import plugin from './plugins/js'

let x = await convert('here', plugin, { framework: 'react' })
```
is correctly typed (eg. `framework` is an enum, and `x` is `void`)